### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ Some implementations in other languages are also available:
 - [Swift](https://github.com/socketio/socket.io-client-swift)
 - [Dart](https://github.com/rikulo/socket.io-client-dart)
 
+[![Run on Repl.it](https://repl.it/badge/github/dead-weight/socket.io)](https://repl.it/github/dead-weight/socket.io)
 Its main features are:
 
 #### Reliability


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


